### PR TITLE
Add contact and terms of use pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,25 +12,9 @@
     href: /occurrence/search
   - text: Literature
     href: /literature/search
-- text: Example pages
-  menu: # Dropdown menu (one level deep only)
-  - text: Simple
-    href: /example-pages/simple
-  - text: Complex
-    href: /example-pages/complex
-- text: Links
-  menu: # Dropdown menu (one level deep only)
-  - text: Base theme demo
-    href: https://hp-base-theme.gbif-staging.org/
-  - text: Other sites using the theme
-    href: https://github.com/gbif/?q=hp-&type=all&language=&sort=
-  - text: "---" # Divider to separate blocks of menu items (at least 3 "-")
-  - text: "Docs" # Title for block of menu items
-  - text: Jekyll documentation
-    href: https://jekyllrb.com/docs/pages/
-  - text: Markdown tutorial
-    href: https://guides.github.com/features/mastering-markdown/
-  - text: YAML tutorial
-    href: https://dev.to/paulasantamaria/introduction-to-yaml-125f
+- text: Contact
+  href: /contact
+- text: Terms of use
+  href: /terms-of-use
 - text: News
   href: /news/

--- a/en/contact.md
+++ b/en/contact.md
@@ -1,0 +1,22 @@
+---
+permalink: contact
+lang-ref: contact
+title: Contact
+height: 70vh
+---
+
+## About
+
+Please direct all enquiries to:
+
+**Shyama Pagad**
+
+Deputy Chair Information, IUCN SSC Invasive Species Specialist Group / University of Auckland, Auckland, New Zealand
+
+s.pagad@auckland.ac.nz
+
+## How to Contribute
+
+Please help us to maintain the most accurate and up-to-date Global Register of Introduced and Invasive Species.
+
+IUCN ISSG endeavors to maintain accurate and up-to-date data at all times. However, if errors or omissions are identified, the user should notify s.pagad@auckland.ac.nz so that these can be corrected in future releases of the data.

--- a/en/terms-of-use.md
+++ b/en/terms-of-use.md
@@ -1,0 +1,35 @@
+---
+permalink: terms-of-use
+lang-ref: terms-of-use
+title: Terms of use
+height: 70vh
+---
+
+# Terms of use
+
+1. The data are supplied only for conservation purposes, scientific analysis or research.
+
+2. The recipient of the data will provide a full and appropriate acknowledgement and citation in any materials or publications derived in part or in whole from the data; relevant citation details will be provided with each dataset. For any publications making substantial use of the data, IUCN Invasive Species Specialist Group (ISSG) welcome the opportunity for co-authorship, collaboration and to comment prior to publication. Expressions of interest can be sent to [s.pagad@auckland.ac.nz](mailto:s.pagad@auckland.ac.nz).
+
+3. Reproduction of the dataset or products derived from it, either whole or in part, for commercial purposes is prohibited without prior written permission from a representative of IUCN ISSG. For the purposes of these Terms of Use, "commercial purposes" means:
+   - a) Any use by, on behalf of, or to inform or assist the activities of, a commercial entity (an entity that operates "for profit").
+   - b) Use by any non-profit entity for the purposes of revenue generation.
+   If you require permission, please contact [s.pagad@auckland.ac.nz](mailto:s.pagad@auckland.ac.nz).
+
+4. The recipient will not publish the data in their original format, either whole or in part, on a website, FTP site, CD, memory stick or any other media. The recipient should provide a link to the original data source location at [griis.org](https://web.archive.org/web/20241004233351/https://griis.org/) where appropriate.
+
+5. Use of these data does not constitute endorsement by IUCN ISSG of any derived products, reports or analyses. IUCN ISSG logo must not be used on any derived products, reports or analyses, or supporting materials, without express permission.
+
+6. The recipient will only use the data provided for the purpose for which it was requested. If subsequent or different use is required, the recipient must contact IUCN ISSG at [s.pagad@auckland.ac.nz](mailto:s.pagad@auckland.ac.nz) again for written approval.
+
+7. The recipient will not pass the original datasets on to third parties and will direct all requests for use of the data back to the IUCN ISSG at [s.pagad@auckland.ac.nz](mailto:s.pagad@auckland.ac.nz).
+
+8. The recipient may only pass on datasets derived from the data supplied by IUCN ISSG if these derived data are supplied with the same terms of use.
+
+9. IUCN ISSG reserve the right to comment on the accuracy of representation of the data in material produced by a recipient.
+
+10. IUCN ISSG endeavour to maintain accurate and up-to-date data at all times, but can accept no responsibility for the consequences of errors or omissions in the data, for misuse of the data by any organization or individual, or for any damage done to computing systems into which the data are entered (see Disclaimer). Either an electronic or two paper copies of all products published using data supplied by IUCN ISSG will be sent, free of charge, via email to [s.pagad@auckland.ac.nz](mailto:s.pagad@auckland.ac.nz).
+
+## Disclaimer
+
+IUCN ISSG makes no warranties or representations, express or implied, regarding the use of the material appearing in this dataset with regard to their correctness, reliability, accuracy, or otherwise. The material and geographic designations in this dataset do not imply the expressions of any opinion whatsoever on the part of IUCN ISSG concerning the legal status of any country, territory or area, nor concerning the delimitation of its frontiers or boundaries. None of IUCN ISSG nor any affiliated or related entities or content providers shall be responsible or liable to any person, firm or corporation for any loss, damage, injury, claim or liability of any kind or character based on or resulting from any information contained in the dataset. IUCN ISSG may update or make changes to the data provided at any time without notice; but no commitment is made to update the information contained therein.


### PR DESCRIPTION
This PR migrates the contact and terms of use page text from https://griis.org/contact and https://griis.org/terms_of_use